### PR TITLE
Feature/adding capability of dynamic next hop ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ route_table = {
 }
 ```
 
+## next_hop_in_dynamic_private_ip
+(Optional) String in CIDR format of next hop ip address in route. If parameter 'next_hop_in_dynamic_private_ip' is not passed in to the module, then property 'next_hop_in_ip_address' is mandatory for next_hop_type = "VitualAppliance" in tfvars file as defined above.
+If the parameter 'next_hop_in_dynamic_private_ip' is passed in to the module, it has priority over 'next_hop_in_ip_address' in tfvars file and always overrides it.
+
 
 ## tags
 (Required) Map of tags for the deployment

--- a/module.tf
+++ b/module.tf
@@ -13,7 +13,7 @@ resource "azurerm_route_table" "route_table" {
               name                        = route.value.name 
               address_prefix              = route.value.prefix
               next_hop_type               = route.value.next_hop_type
-              next_hop_in_ip_address      = "${contains(keys(route.value), "next_hop_in_ip_address") ? route.value.next_hop_in_ip_address : null}"
+              next_hop_in_ip_address      = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_ip_address != null && var.next_hop_in_ip_address != "null" && var.next_hop_in_ip_address != "" ? var.next_hop_in_ip_address : route_value.next_hop_in_ip_address) : null
             }
     } 
 }

--- a/module.tf
+++ b/module.tf
@@ -13,7 +13,7 @@ resource "azurerm_route_table" "route_table" {
               name                        = route.value.name 
               address_prefix              = route.value.prefix
               next_hop_type               = route.value.next_hop_type
-              next_hop_in_ip_address      = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_ip_address != null && var.next_hop_in_ip_address != "null" && var.next_hop_in_ip_address != "" ? var.next_hop_in_ip_address : route_value.next_hop_in_ip_address) : null
+              next_hop_in_ip_address      = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route_value.next_hop_in_ip_address) : null
             }
     } 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,8 @@ variable "route_table" {
    description = "(Required) route table object to be created"
  
 }
+
+variable next_hop_in_ip_address {
+   description = "(Optional) dynamically passing gateway ip which is output of another terraform resource, e.g. azure firewall private ip"
+   default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "route_table" {
  
 }
 
-variable next_hop_in_ip_address {
-   description = "(Optional) dynamically passing gateway ip which is output of another terraform resource, e.g. azure firewall private ip"
+variable next_hop_in_dynamic_private_ip {
+   description = "(Optional) dynamically passing private ip address which is an output of another tf resource or module, e.g. azure firewall"
    default = null
 }


### PR DESCRIPTION
Usually, when deploying routes with next_hop_type = "VirtualAppliance" you are not aware ahead of next hop ip of given appliance, e.g. azure firewall. Hence you are not able to defined it ahead in tfvars file. This small change extending the module of optional parameter which is called "next_hop_in_dynamic_private_ip" which can be dynamically taken from the deployment runtime as output of virtual appliance resource, e.g. azure firewall