### PR TITLE
Feature/support address prefix as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "route_table" {
 | max\_length | (Optional) You can speficy a maximum length to the name of the resource | `string` | `"60"` | no |
 | next\_hop\_in\_dynamic\_private\_ip | (Optional) dynamically passing private ip address which is an output of another tf resource or module, e.g. azure firewall | `any` | `null` | no |
 | postfix | (Optional) You can use a postfix to the name of the resource | `string` | `""` | no |
-| prefix | (Required) network address prefix | `string` or `array` | `""` | yes |
+| prefix | (Optional) You can use a prefix to the name of the resource | `string` | `""` | no |
 | route\_table | (Required) route table object to be created | `any` | n/a | yes |
 | tags | (Required) map of tags for the deployment | `any` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module "route_table" {
 | max\_length | (Optional) You can speficy a maximum length to the name of the resource | `string` | `"60"` | no |
 | next\_hop\_in\_dynamic\_private\_ip | (Optional) dynamically passing private ip address which is an output of another tf resource or module, e.g. azure firewall | `any` | `null` | no |
 | postfix | (Optional) You can use a postfix to the name of the resource | `string` | `""` | no |
-| prefix | (Optional) You can use a prefix to the name of the resource | `string` | `""` | no |
+| prefix | (Required) network address prefix | `string` or `array` | `""` | yes |
 | route\_table | (Required) route table object to be created | `any` | n/a | yes |
 | tags | (Required) map of tags for the deployment | `any` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -42,16 +42,25 @@ module "route_table" {
 ## route_table
 (Required) The routing table object describing the route table configuration
 Mandatory properties are:
-- name
-- at least one route_entries item as follow:
+- name (type=string)
+- route_entries (type=object)
+  - name (type=string)
+  - prefix (type=string or type=array)
+  - next_hop_type (type=string)
+  - next_hop_in_ip_address (type=string)
 ```hcl
   re1= {
             name                        = "myroute1"
             prefix                      = "255.0.0.0/8"
             next_hop_type               = "None"
-            next_hop_in_ip_address      = "192.168.10.5" #required if next_hop_type is "VirtualAppliance"
+        },
+  re2= {
+          name                        = "myroute1"
+          prefix                      = ["10.10.1.0/24","10.10.2.0/24"]
+          next_hop_type               = "VirtualAppliance"
+          next_hop_in_ip_address      = "192.168.10.5" #required if next_hop_type is "VirtualAppliance"
 
-          },
+        },
 ```
 Optional fields:
 - disable_bgp_route_propagation

--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,9 @@ locals {
 
 terraform {
   required_providers {
-    # azurecaf = {
-    #   source = "aztfmod/azurecaf"
-    # }
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+    }
     azurerm = {
       source = "hashicorp/azurerm"
     }

--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,9 @@ locals {
 
 terraform {
   required_providers {
-    azurecaf = {
-      source = "aztfmod/azurecaf"
-    }
+    # azurecaf = {
+    #   source = "aztfmod/azurecaf"
+    # }
     azurerm = {
       source = "hashicorp/azurerm"
     }

--- a/module.tf
+++ b/module.tf
@@ -1,19 +1,35 @@
 #Reference https://www.terraform.io/docs/providers/azurerm/r/route_table.html
 
 resource "azurerm_route_table" "route_table" {
-  name                          = var.route_table.name
+  for_each = var.route_table
+
+  name                          = each.value["name"]
   location                      = var.location
   resource_group_name           = var.resource_group_name
   tags                          = local.tags
   disable_bgp_route_propagation = lookup(var.route_table, "disable_bgp_route_propagation", null)
 
   dynamic "route" {
-    for_each = var.route_table.route_entries
+    for_each = flatten(
+      [
+          for route_key,route_value in each.value["route_entries"]:
+          [
+            for address_key, address_value in flatten(list(route_value.address_prefix)):
+            {
+              name                   = replace(join("-",list(route_value.name,address_value)),"/","_")
+              address_prefix         = address_value
+              next_hop_type          = route_value.next_hop_type
+              next_hop_in_ip_address = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route.value.next_hop_in_ip_address) : null
+            }
+          ]
+      ]
+    )
+    
     content {
       name                   = route.value.name
-      address_prefix         = route.value.prefix
+      address_prefix         = route.value.address_prefix
       next_hop_type          = route.value.next_hop_type
-      next_hop_in_ip_address = route.value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route.value.next_hop_in_ip_address) : null
+      next_hop_in_ip_address = route.value.next_hop_in_ip_address
     }
   }
 }

--- a/module.tf
+++ b/module.tf
@@ -10,14 +10,14 @@ resource "azurerm_route_table" "route_table" {
   dynamic "route" {
     for_each = flatten(
       [
-          for route_key,route_value in var.route_table.route_entries:
+          for route_key,route_value in var.route_table.route_entries :
           [
             for address_key, address_value in flatten(list(route_value.address_prefix)): # flatten(list()) handles support for both array & string
             {
               name                   = replace(join("-",list(route_value.name,address_value)),"/","_") # build name from route table name + address prefix, escape slash
               address_prefix         = address_value
               next_hop_type          = route_value.next_hop_type
-              next_hop_in_ip_address = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route.value.next_hop_in_ip_address) : null
+              next_hop_in_ip_address = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route_value.next_hop_in_ip_address) : null
             }
           ]
       ]

--- a/module.tf
+++ b/module.tf
@@ -12,7 +12,7 @@ resource "azurerm_route_table" "route_table" {
       [
           for route_key,route_value in var.route_table.route_entries :
           [
-            for address_key, address_value in flatten(list(route_value.address_prefix)): # flatten(list()) handles support for both array & string
+            for address_key, address_value in flatten(list(route_value.prefix)): # flatten(list()) handles support for both array & string
             {
               name                   = replace(join("-",list(route_value.name,address_value)),"/","_") # build name from route table name + address prefix, escape slash
               address_prefix         = address_value

--- a/module.tf
+++ b/module.tf
@@ -1,9 +1,7 @@
 #Reference https://www.terraform.io/docs/providers/azurerm/r/route_table.html
 
 resource "azurerm_route_table" "route_table" {
-  for_each = var.route_table
-
-  name                          = each.value["name"]
+  name                          = var.route_table.name
   location                      = var.location
   resource_group_name           = var.resource_group_name
   tags                          = local.tags
@@ -12,7 +10,7 @@ resource "azurerm_route_table" "route_table" {
   dynamic "route" {
     for_each = flatten(
       [
-          for route_key,route_value in each.value["route_entries"]:
+          for route_key,route_value in var.route_table.route_entries:
           [
             for address_key, address_value in flatten(list(route_value.address_prefix)):
             {

--- a/module.tf
+++ b/module.tf
@@ -12,9 +12,9 @@ resource "azurerm_route_table" "route_table" {
       [
           for route_key,route_value in var.route_table.route_entries:
           [
-            for address_key, address_value in flatten(list(route_value.address_prefix)):
+            for address_key, address_value in flatten(list(route_value.address_prefix)): # flatten(list()) handles support for both array & string
             {
-              name                   = replace(join("-",list(route_value.name,address_value)),"/","_")
+              name                   = replace(join("-",list(route_value.name,address_value)),"/","_") # build name from route table name + address prefix, escape slash
               address_prefix         = address_value
               next_hop_type          = route_value.next_hop_type
               next_hop_in_ip_address = route_value.next_hop_type == "VirtualAppliance" ? (var.next_hop_in_dynamic_private_ip != null && var.next_hop_in_dynamic_private_ip != "null" && var.next_hop_in_dynamic_private_ip != "" ? var.next_hop_in_dynamic_private_ip : route.value.next_hop_in_ip_address) : null


### PR DESCRIPTION
# Description

There is usually situation when you need to override the default route of VNET or vnet peering by your custom rule which defines custom next hop (e.g. azure firewall). VNET can define multiple address spaces not only one. It is handy to define them as array. Of course it could be defined separately as new entry with new name and its address space - if you don't find it use-full, feel free to abandon the PR. The name of such route entry is then created by concatenation of the "route entry name" + "address space".

# Enhancement

- Adding support for address prefix defined as **array**. 
- Keeping backward compatibility of address prefix being type of string as well. 
- Extending capability of input tfvars which can define address prefix as array ["10.10.1.0/24","10.10.2.0/24"]. 


# Example of tfvars

```
route_table = {
    name = "test_route"
    route_entries = {
      re1 = {
        name          = "myroute1"
        prefix        = "255.0.0.0/8"
        next_hop_type = "None"
      },
      re2 = {
        name                   = "myroute2"
        prefix                 = ["255.255.0.0/16","8.8.8.8/32"]
        next_hop_type          = "VirtualAppliance"
        next_hop_in_ip_address = "192.168.10.6"
      },
      re3 = {
        name                   = "defaultroute"
        prefix                 = "0.0.0.0/0"
        next_hop_type          = "VirtualAppliance"
        next_hop_in_ip_address = "192.168.10.5"
      },
    }
}
```

# Tested:

```
# azurerm_resource_group.rg1 will be created
  + resource "azurerm_resource_group" "rg1" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "test-route-table"
    }

 # module.route_table_test.azurerm_route_table.route_table will be created
  + resource "azurerm_route_table" "route_table" {
      + disable_bgp_route_propagation = false
      + id                            = (known after apply)
      + location                      = "westeurope"
      + name                          = "test_route"
      + resource_group_name           = "test-route-table"
      + route                         = [
          + {
              + address_prefix         = "255.0.0.0/8"
              + name                   = "myroute1-255.0.0.0_8"
              + next_hop_in_ip_address = null
              + next_hop_type          = "None"
            },
          + {
              + address_prefix         = "255.255.0.0/16"
              + name                   = "myroute2-255.255.0.0_16"
              + next_hop_in_ip_address = "192.168.10.6"
              + next_hop_type          = "VirtualAppliance"
            },
          + {
              + address_prefix         = "8.8.8.8/32"
              + name                   = "myroute2-8.8.8.8_32"
              + next_hop_in_ip_address = "192.168.10.6"
              + next_hop_type          = "VirtualAppliance"
            },
          + {
              + address_prefix         = "0.0.0.0/0"
              + name                   = "defaultroute-0.0.0.0_0"
              + next_hop_in_ip_address = "192.168.10.5"
              + next_hop_type          = "VirtualAppliance"
            },
        ]
      + subnets                       = (known after apply)
      + tags                          = {
          + "deployment" = "by terraform"
          + "module"     = "route_table"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```